### PR TITLE
fix(backend): honor APP_PORT env and sync Go module dependencies

### DIFF
--- a/backend/cmd/app/app.go
+++ b/backend/cmd/app/app.go
@@ -1012,8 +1012,11 @@ func Start(db *gorm.DB) {
 	// Adicione a rotina de desativação de orçamentos
 	go deactivateExpiredBudgetsRoutine(dependency.BudgetService)
 
-	// server := newServer(os.Getenv("APP_PORT"), router)
-	server := newServer("5000", router)
+	appPort := os.Getenv("APP_PORT")
+	if appPort == "" {
+		appPort = "5000"
+	}
+	server := newServer(appPort, router)
 	server.ListenAndServe()
 
 	stopChan := make(chan os.Signal)
@@ -1035,7 +1038,7 @@ func newServer(port string, handler http.Handler) *Server {
 
 func (s *Server) ListenAndServe() {
 	go func() {
-		fmt.Println("Server runing in port 5000")
+		fmt.Printf("Server runing in port %s\n", s.server.Addr)
 		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			fmt.Printf("erro: %s", err)
 		}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,25 +1,54 @@
 module construir_mais_barato
 
-go 1.22.5
+go 1.25.8
 
 require (
+	firebase.google.com/go/v4 v4.20.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.12.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.11.1
 	github.com/xuri/excelize/v2 v2.8.1
-	golang.org/x/crypto v0.23.0
+	golang.org/x/crypto v0.53.0
+	google.golang.org/api v0.287.0
 	gorm.io/driver/mysql v1.5.6
 	gorm.io/driver/sqlite v1.5.5
 	gorm.io/gorm v1.25.10
 )
 
 require (
+	cel.dev/expr v0.25.2 // indirect
+	cloud.google.com/go v0.123.0 // indirect
+	cloud.google.com/go/auth v0.20.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/firestore v1.22.0 // indirect
+	cloud.google.com/go/iam v1.11.0 // indirect
+	cloud.google.com/go/longrunning v1.0.0 // indirect
+	cloud.google.com/go/monitoring v1.29.0 // indirect
+	cloud.google.com/go/storage v1.62.1 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0 // indirect
+	github.com/MicahParks/keyfunc v1.9.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect
+	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
@@ -27,17 +56,36 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.3 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xuri/efp v0.0.0-20231025114914-d1ff6096ae53 // indirect
 	github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05 // indirect
-	golang.org/x/net v0.25.0 // indirect
-	golang.org/x/sys v0.20.0 // indirect
-	golang.org/x/text v0.15.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/text v0.38.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
+	google.golang.org/appengine/v2 v2.0.6 // indirect
+	google.golang.org/genproto v0.0.0-20260511170946-3700d4141b60 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260511170946-3700d4141b60 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect
+	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Summary

Makes the backend HTTP server respect the `APP_PORT` environment variable (with a safe default) and refreshes `go.mod` so local/runtime dependency resolution matches the project’s current stack.

## Problem / motivation

- The server listen port was hardcoded to `"5000"` even though `.env.example` already documented `APP_PORT`. The real `os.Getenv("APP_PORT")` call was commented out, so deploys and local setups could not change the port without editing code.
- Startup logs always printed “port 5000”, which was misleading when the intended port differed.
- `go.mod` was out of sync with the codebase (Firebase / Google API usage and transitive deps), which risks broken `go build` / `go mod tidy` on clean environments.

## What changed

### Server port configuration (`backend/cmd/app/app.go`)
- Read `APP_PORT` from the environment.
- Fall back to `"5000"` when unset (keeps current default behavior).
- Pass the resolved value into `newServer(...)`.
- Log the actual listen address instead of a hardcoded `5000`.

### Dependency sync (`backend/go.mod`)
- Bump Go toolchain declaration (`1.22.5` → `1.25.8`).
- Declare direct deps already used by the app (e.g. `firebase.google.com/go/v4`, `google.golang.org/api`).
- Refresh related indirect modules (`golang.org/x/*`, OpenTelemetry, gRPC/protobuf, etc.).

## Commit included

- `fix(backend): use APP_PORT env and sync go dependencies`

## Scope (files)

| File | Change |
|------|--------|
| `backend/cmd/app/app.go` | Configurable port + accurate startup log |
| `backend/go.mod` | Module / Go version / dependency sync |

2 files · +63 / −12

## How to test

- [ ] With no `APP_PORT` set → server starts on `5000` and log shows that address
- [ ] Set `APP_PORT=8080` (or another free port) in `.env` / shell → server binds to that port; log matches
- [ ] Confirm `.env.example` still documents `APP_PORT=5000` and matches runtime behavior
- [ ] From `backend/`: `go mod tidy` / `go build ./...` succeeds on a clean checkout
- [ ] Smoke: hit a known public health/route endpoint on the configured port

### Edge cases
- [ ] Empty string `APP_PORT=` → treated as unset and falls back to `5000`
- [ ] Invalid / already-in-use port → process fails loudly at listen time (expected)

## Technical notes / decisions

- Kept **default `5000`** to avoid breaking existing local scripts, Docker/devopness configs, and docs that already assume that port.
- Prefer env-driven config over recompiling for different environments (local vs staging vs container mapping).
- `go.mod` sync is bundled here because the branch needed a consistent build after Firebase/Google deps were already in use; reviewers should treat the module bump as **build hygiene**, not an API behavior change.

## Risks / follow-ups

- Go version bump in `go.mod` may require CI/agents to run a newer Go toolchain — confirm pipeline image/toolchain supports `1.25.x` (or adjust the `go` directive if the team standard is still 1.22).
- Large transitive dependency refresh increases review surface; worth verifying no unexpected license/security alerts in CI.
- Startup message still contains the typo “runing” (pre-existing); optional follow-up cleanup.

## Checklist

- [x] Conventional commit message (`fix(backend): ...`)
- [x] Behavior preserves previous default when env is missing
- [ ] Verified bind port with and without `APP_PORT`
- [ ] Verified clean `go build` after module sync
- [ ] Confirmed deploy/CI Go version compatibility
- [ ] No unrelated feature code in the diff