### PR TITLE
feat: simplify budget forms UX and add page-view analytics

### DIFF
--- a/backend/app/domain/pageview/entity.go
+++ b/backend/app/domain/pageview/entity.go
@@ -1,0 +1,9 @@
+package pageview
+
+import "gorm.io/gorm"
+
+type PageView struct {
+	gorm.Model
+	Path  string `gorm:"uniqueIndex;size:255;not null"`
+	Count int64  `gorm:"default:0"`
+}

--- a/backend/app/domain/pageview/repository.go
+++ b/backend/app/domain/pageview/repository.go
@@ -1,0 +1,6 @@
+package pageview
+
+type PageViewRepository interface {
+	Increment(path string) (*PageView, error)
+	FindAll() ([]*PageView, error)
+}

--- a/backend/app/domain/pageview/service.go
+++ b/backend/app/domain/pageview/service.go
@@ -1,0 +1,24 @@
+package pageview
+
+type PageViewService interface {
+	Increment(path string) (*PageView, error)
+	FindAll() ([]*PageView, error)
+}
+
+type pageViewService struct {
+	repository PageViewRepository
+}
+
+func NewPageViewService(repository PageViewRepository) PageViewService {
+	return &pageViewService{
+		repository: repository,
+	}
+}
+
+func (s *pageViewService) Increment(path string) (*PageView, error) {
+	return s.repository.Increment(path)
+}
+
+func (s *pageViewService) FindAll() ([]*PageView, error) {
+	return s.repository.FindAll()
+}

--- a/backend/app/usecase/pageview/find-all.go
+++ b/backend/app/usecase/pageview/find-all.go
@@ -1,0 +1,31 @@
+package pageview_usecase
+
+import (
+	pkgpageview "construir_mais_barato/app/domain/pageview"
+)
+
+type FindAllPageViewsUCParams struct {
+	Service pkgpageview.PageViewService
+}
+
+type FindAllPageViewsUC struct {
+	Service pkgpageview.PageViewService
+}
+
+func NewFindAllPageViewsUC(params FindAllPageViewsUCParams) FindAllPageViewsUC {
+	return FindAllPageViewsUC{
+		Service: params.Service,
+	}
+}
+
+func (uc *FindAllPageViewsUC) Execute() ([]PageViewPresenter, error) {
+	pageViews, err := uc.Service.FindAll()
+	if err != nil {
+		return nil, err
+	}
+	presenters := make([]PageViewPresenter, 0, len(pageViews))
+	for _, pageView := range pageViews {
+		presenters = append(presenters, GeneratePageViewPresenter(pageView))
+	}
+	return presenters, nil
+}

--- a/backend/app/usecase/pageview/increment.go
+++ b/backend/app/usecase/pageview/increment.go
@@ -1,0 +1,33 @@
+package pageview_usecase
+
+import (
+	pkgpageview "construir_mais_barato/app/domain/pageview"
+)
+
+type IncrementPageViewUCParams struct {
+	Service pkgpageview.PageViewService
+}
+
+type IncrementPageViewAssembler struct {
+	Path string `json:"path"`
+}
+
+type IncrementPageViewUC struct {
+	Service   pkgpageview.PageViewService
+	Assembler *IncrementPageViewAssembler
+}
+
+func NewIncrementPageViewUC(params IncrementPageViewUCParams) IncrementPageViewUC {
+	return IncrementPageViewUC{
+		Service: params.Service,
+	}
+}
+
+func (uc *IncrementPageViewUC) Execute() (*PageViewPresenter, error) {
+	pageView, err := uc.Service.Increment(uc.Assembler.Path)
+	if err != nil {
+		return nil, err
+	}
+	presenter := GeneratePageViewPresenter(pageView)
+	return &presenter, nil
+}

--- a/backend/app/usecase/pageview/presenter.go
+++ b/backend/app/usecase/pageview/presenter.go
@@ -1,0 +1,22 @@
+package pageview_usecase
+
+import (
+	pkgpageview "construir_mais_barato/app/domain/pageview"
+)
+
+type PageViewPresenter struct {
+	ID    uint   `json:"id"`
+	Path  string `json:"path"`
+	Count int64  `json:"count"`
+}
+
+func GeneratePageViewPresenter(pageView *pkgpageview.PageView) PageViewPresenter {
+	if pageView == nil {
+		return PageViewPresenter{}
+	}
+	return PageViewPresenter{
+		ID:    pageView.ID,
+		Path:  pageView.Path,
+		Count: pageView.Count,
+	}
+}

--- a/backend/cmd/app/app.go
+++ b/backend/cmd/app/app.go
@@ -80,10 +80,13 @@ import (
 	pkgplaninfra "construir_mais_barato/infra/database/repositories/plan"
 
 	pkgexchangecodes "construir_mais_barato/app/domain/exchange-codes"
+	pkgpageview "construir_mais_barato/app/domain/pageview"
 	pkgsolicitationapp "construir_mais_barato/app/domain/solicitationAPP"
 	pkgsolicitationappuc "construir_mais_barato/app/usecase/solicitation"
+	pkgpageviewuc "construir_mais_barato/app/usecase/pageview"
 	pkgexchangecodeinfra "construir_mais_barato/infra/database/repositories/exchange-code"
 	pkgsolicitationappinfra "construir_mais_barato/infra/database/repositories/solicitationAPP"
+	pkgpageviewinfra "construir_mais_barato/infra/database/repositories/pageview"
 
 	pkgauthenticateuc "construir_mais_barato/app/usecase/auth"
 	pkgnotificationuc "construir_mais_barato/app/usecase/notification"
@@ -116,6 +119,7 @@ type dependenceParams struct {
 	RegionService               pkgregion.RegionService
 	PlanService                 pkgplan.PlanService
 	SolicitationAppService      pkgsolicitationapp.SolicitationAppService
+	PageViewService             pkgpageview.PageViewService
 	MercadoPagoClient           *mercadopago.MPClient
 	SendAppNotificationUCParams pkgnotificationuc.SendAppNotificationUCParams
 }
@@ -141,6 +145,7 @@ func buildDependenciesParams(db *gorm.DB) dependenceParams {
 	params.RegionService = pkgregion.NewRegionService(pkgregioninfra.NewRegionRepositoryImpl(db))
 	params.PlanService = pkgplan.NewPlanService(pkgplaninfra.NewPlanRepositoryImpl(db))
 	params.SolicitationAppService = pkgsolicitationapp.NewSolicitationAppService(pkgsolicitationappinfra.NewSolicitationAppRepositoryImpl(db))
+	params.PageViewService = pkgpageview.NewPageViewService(pkgpageviewinfra.NewPageViewRepositoryImpl(db))
 	params.MercadoPagoClient = mercadopago.NewMPClient(os.Getenv("MERCADOPAGO_ACCESS_TOKEN"), os.Getenv("MERCADOPAGO_BASE_URL_API"))
 	params.SendAppNotificationUCParams = pkgnotificationuc.SendAppNotificationUCParams{
 		UserService:         params.UserService,
@@ -787,6 +792,10 @@ func buildPublicEndPoint(dependency *dependenceParams, g *echo.Group) {
 		PlanService: dependency.PlanService,
 	}
 
+	incrementPageViewUCParams := pkgpageviewuc.IncrementPageViewUCParams{
+		Service: dependency.PageViewService,
+	}
+
 	// parametros do userController
 	publicControllerParams := pkgcontrollers.PublicControllerParams{
 		FindRegionByCityIdUCParams:                          findRegionByCityUCParams,
@@ -816,6 +825,7 @@ func buildPublicEndPoint(dependency *dependenceParams, g *echo.Group) {
 		CheckoutProfessionalPremiumUCParams:                 checkoutProfessionalPremiumUCParams,
 		CheckoutStorePremiumUCParams:                        checkoutStorePremiumUCParams,
 		FindStoreByCategoryAndSubCategoryParams:             findByCategoryAndSubCategories,
+		IncrementPageViewUCParams:                           incrementPageViewUCParams,
 	}
 
 	pkgcontrollers.NewPublicController(&publicControllerParams, g)
@@ -963,6 +973,18 @@ func buildNotificationEndPoint(dependency *dependenceParams, g *echo.Group) {
 	pkgcontrollers.NewNotificationController(&notificationControllerParams, g)
 }
 
+func buildPageViewEndPoint(dependency *dependenceParams, g *echo.Group) {
+	findAllPageViewsUCParams := pkgpageviewuc.FindAllPageViewsUCParams{
+		Service: dependency.PageViewService,
+	}
+
+	pageViewControllerParams := pkgcontrollers.PageViewControllerParams{
+		FindAllPageViewsUCParams: findAllPageViewsUCParams,
+	}
+
+	pkgcontrollers.NewPageViewController(&pageViewControllerParams, g)
+}
+
 func Start(db *gorm.DB) {
 
 	dependency := buildDependenciesParams(db)
@@ -1008,6 +1030,7 @@ func Start(db *gorm.DB) {
 	buildRegionEndPoint(&dependency, routerGroup)
 	buildNotificationEndPoint(&dependency, routerGroup)
 	buildSolicitationEndPoint(&dependency, routerGroup)
+	buildPageViewEndPoint(&dependency, routerGroup)
 
 	// Adicione a rotina de desativação de orçamentos
 	go deactivateExpiredBudgetsRoutine(dependency.BudgetService)

--- a/backend/cmd/app/app.go
+++ b/backend/cmd/app/app.go
@@ -1012,8 +1012,11 @@ func Start(db *gorm.DB) {
 	// Adicione a rotina de desativação de orçamentos
 	go deactivateExpiredBudgetsRoutine(dependency.BudgetService)
 
-	// server := newServer(os.Getenv("APP_PORT"), router)
-	server := newServer("5000", router)
+	appPort := os.Getenv("APP_PORT")
+	if appPort == "" {
+		appPort = "5000"
+	}
+	server := newServer(appPort, router)
 	server.ListenAndServe()
 
 	stopChan := make(chan os.Signal)
@@ -1035,7 +1038,7 @@ func newServer(port string, handler http.Handler) *Server {
 
 func (s *Server) ListenAndServe() {
 	go func() {
-		fmt.Println("Server runing in port 5000")
+		fmt.Printf("Server runing in port %s\n", s.server.Addr)
 		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			fmt.Printf("erro: %s", err)
 		}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,25 +1,54 @@
 module construir_mais_barato
 
-go 1.22.5
+go 1.25.8
 
 require (
+	firebase.google.com/go/v4 v4.20.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.12.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.11.1
 	github.com/xuri/excelize/v2 v2.8.1
-	golang.org/x/crypto v0.23.0
+	golang.org/x/crypto v0.53.0
+	google.golang.org/api v0.287.0
 	gorm.io/driver/mysql v1.5.6
 	gorm.io/driver/sqlite v1.5.5
 	gorm.io/gorm v1.25.10
 )
 
 require (
+	cel.dev/expr v0.25.2 // indirect
+	cloud.google.com/go v0.123.0 // indirect
+	cloud.google.com/go/auth v0.20.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/firestore v1.22.0 // indirect
+	cloud.google.com/go/iam v1.11.0 // indirect
+	cloud.google.com/go/longrunning v1.0.0 // indirect
+	cloud.google.com/go/monitoring v1.29.0 // indirect
+	cloud.google.com/go/storage v1.62.1 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0 // indirect
+	github.com/MicahParks/keyfunc v1.9.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect
+	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
@@ -27,17 +56,36 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/richardlehane/mscfb v1.0.4 // indirect
 	github.com/richardlehane/msoleps v1.0.3 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xuri/efp v0.0.0-20231025114914-d1ff6096ae53 // indirect
 	github.com/xuri/nfp v0.0.0-20230919160717-d98342af3f05 // indirect
-	golang.org/x/net v0.25.0 // indirect
-	golang.org/x/sys v0.20.0 // indirect
-	golang.org/x/text v0.15.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.68.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
+	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/text v0.38.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
+	google.golang.org/appengine/v2 v2.0.6 // indirect
+	google.golang.org/genproto v0.0.0-20260511170946-3700d4141b60 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260511170946-3700d4141b60 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect
+	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/backend/infra/database/mysql-db/mysql.conn.go
+++ b/backend/infra/database/mysql-db/mysql.conn.go
@@ -21,6 +21,7 @@ import (
 	pkgprofession "construir_mais_barato/app/domain/profession"
 	pkgprofessional "construir_mais_barato/app/domain/professional"
 	pkgregion "construir_mais_barato/app/domain/region"
+	pkgpageview "construir_mais_barato/app/domain/pageview"
 	pkgsolicitationapp "construir_mais_barato/app/domain/solicitationAPP"
 	pkgstore "construir_mais_barato/app/domain/store"
 	pkgsubscription "construir_mais_barato/app/domain/subscription"
@@ -94,6 +95,7 @@ func ConnectionDB(params *ConfigParams) *gorm.DB {
 	db.AutoMigrate(&pkgunlockprice.UnlockPrice{})
 	db.AutoMigrate(&pkgsolicitationapp.SolicitationApp{})
 	db.AutoMigrate(&pkgsexchangecode.ExchangeCode{})
+	db.AutoMigrate(&pkgpageview.PageView{})
 
 	// Seed de planos (popula planos iniciais se não existirem)
 	if err := pkgplan.SeedPlans(db); err != nil {

--- a/backend/infra/database/repositories/pageview/repository-impl.go
+++ b/backend/infra/database/repositories/pageview/repository-impl.go
@@ -1,0 +1,50 @@
+package pageview_repository_impl
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+
+	pkgpageview "construir_mais_barato/app/domain/pageview"
+)
+
+type repository struct {
+	DB *gorm.DB
+}
+
+func NewPageViewRepositoryImpl(db *gorm.DB) pkgpageview.PageViewRepository {
+	return &repository{
+		DB: db,
+	}
+}
+
+func (r *repository) Increment(path string) (*pkgpageview.PageView, error) {
+	var pageView pkgpageview.PageView
+	err := r.DB.Where("path = ?", path).First(&pageView).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		pageView = pkgpageview.PageView{
+			Path:  path,
+			Count: 1,
+		}
+		if createErr := r.DB.Create(&pageView).Error; createErr != nil {
+			return nil, createErr
+		}
+		return &pageView, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	pageView.Count++
+	if saveErr := r.DB.Save(&pageView).Error; saveErr != nil {
+		return nil, saveErr
+	}
+	return &pageView, nil
+}
+
+func (r *repository) FindAll() ([]*pkgpageview.PageView, error) {
+	var pageViews []*pkgpageview.PageView
+	if err := r.DB.Order("count desc").Find(&pageViews).Error; err != nil {
+		return nil, err
+	}
+	return pageViews, nil
+}

--- a/backend/infra/web/controllers/page-view-controller.go
+++ b/backend/infra/web/controllers/page-view-controller.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	pkgpageviewuc "construir_mais_barato/app/usecase/pageview"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type PageViewController struct {
+	FindAllPageViewsUCParams pkgpageviewuc.FindAllPageViewsUCParams
+}
+
+type PageViewControllerParams struct {
+	FindAllPageViewsUCParams pkgpageviewuc.FindAllPageViewsUCParams
+}
+
+func NewPageViewController(params *PageViewControllerParams, g *echo.Group) {
+	controller := PageViewController{
+		FindAllPageViewsUCParams: params.FindAllPageViewsUCParams,
+	}
+
+	g.GET("/page-views", controller.FindAll)
+}
+
+func (c *PageViewController) FindAll(ctx echo.Context) error {
+	usecase := pkgpageviewuc.NewFindAllPageViewsUC(c.FindAllPageViewsUCParams)
+	pageViews, err := usecase.Execute()
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return ctx.JSON(http.StatusOK, pageViews)
+}

--- a/backend/infra/web/controllers/publicController.go
+++ b/backend/infra/web/controllers/publicController.go
@@ -8,6 +8,7 @@ import (
 	pkgclientuc "construir_mais_barato/app/usecase/client"
 	pkgpcontactuc "construir_mais_barato/app/usecase/contact"
 	pkgplanuc "construir_mais_barato/app/usecase/plan"
+	pkgpageviewuc "construir_mais_barato/app/usecase/pageview"
 	pkgpproductuc "construir_mais_barato/app/usecase/product"
 	pkgproductuc "construir_mais_barato/app/usecase/product"
 	pkgprofessionuc "construir_mais_barato/app/usecase/profession"
@@ -57,6 +58,7 @@ type PublicController struct {
 	FindPlanByUserTypeUCParams                          pkgplanuc.FindByUserTypeUCParams
 	CheckoutProfessionalPremiumUCParams                 pkgprofessionaluc.CheckoutPremiumUCParams
 	CheckoutStorePremiumUCParams                        pkgstoreuc.CheckoutPremiumUCParams
+	IncrementPageViewUCParams                           pkgpageviewuc.IncrementPageViewUCParams
 }
 
 type PublicControllerParams struct {
@@ -87,6 +89,7 @@ type PublicControllerParams struct {
 	FindPlanByUserTypeUCParams                          pkgplanuc.FindByUserTypeUCParams
 	CheckoutProfessionalPremiumUCParams                 pkgprofessionaluc.CheckoutPremiumUCParams
 	CheckoutStorePremiumUCParams                        pkgstoreuc.CheckoutPremiumUCParams
+	IncrementPageViewUCParams                           pkgpageviewuc.IncrementPageViewUCParams
 }
 
 func NewPublicController(params *PublicControllerParams, g *echo.Group) {
@@ -118,6 +121,7 @@ func NewPublicController(params *PublicControllerParams, g *echo.Group) {
 		CheckoutProfessionalPremiumUCParams:                 params.CheckoutProfessionalPremiumUCParams,
 		CheckoutStorePremiumUCParams:                        params.CheckoutStorePremiumUCParams,
 		FindStoreByCategoryAndSubCategoryParams:             params.FindStoreByCategoryAndSubCategoryParams,
+		IncrementPageViewUCParams:                           params.IncrementPageViewUCParams,
 	}
 
 	g.GET("/plans", controller.GetActivePlans)
@@ -150,6 +154,7 @@ func NewPublicController(params *PublicControllerParams, g *echo.Group) {
 	g.POST("/category-and-sub", controller.FindStoreByCategoryAndSubCategory)
 	g.POST("/save/client", controller.SaveClient)
 	g.POST("/upload/image", controller.uploadFile)
+	g.POST("/page-view", controller.TrackPageView)
 
 }
 
@@ -305,6 +310,24 @@ func (c *PublicController) SaveBudget(ctx echo.Context) error {
 	}
 	return ctx.JSON(http.StatusOK, budget)
 
+}
+
+func (c *PublicController) TrackPageView(ctx echo.Context) error {
+	defer ctx.Request().Body.Close()
+	usecase := pkgpageviewuc.NewIncrementPageViewUC(c.IncrementPageViewUCParams)
+	assembler := pkgpageviewuc.IncrementPageViewAssembler{}
+	if err := ctx.Bind(&assembler); err != nil {
+		return ctx.JSON(http.StatusPreconditionFailed, err)
+	}
+	if assembler.Path == "" {
+		assembler.Path = "/"
+	}
+	usecase.Assembler = &assembler
+	pageView, err := usecase.Execute()
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return ctx.JSON(http.StatusOK, pageView)
 }
 
 func (c *PublicController) FindProfessionsWithCount(ctx echo.Context) error {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Dashboard from "./pages/Dashboard";
 import Footer from "./components/Footer";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { usePageViewTracker } from "./hooks/usePageViewTracker";
 import Home from "./pages/Home";
 import Header from "./components/Header";
 import BannerHeader from "./components/BannerHeader";
@@ -17,30 +18,40 @@ import ResetPassword from "./pages/ResetPassword";
 import QuoteProducts from "./pages/QuoteProducts";
 import ProductCategoriesAdmin from "./pages/ProductCategoriesAdmin";
 
+function AppContent() {
+  usePageViewTracker()
+
+  return (
+    <>
+      <Header></Header>
+      <BannerHeader></BannerHeader>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="/marketplace" element={<Marketplace />} />
+        <Route path="/search" element={<SearchProfessionals />} />
+        <Route path="/quote-product" element={<QuoteProducts />} />
+        <Route path="/privacy" element={<PrivacyPolicy />} />
+        <Route path="/checkout" element={<Checkout />} />
+        <Route path="/checkout-unlock" element={<CheckoutUnlock />} />
+
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/search-results" element={<SearchResults />} />
+        <Route path="/professional-panel" element={<ProfessionalPanel />} />
+        <Route path="/product-categories-admin" element={<ProductCategoriesAdmin />} />
+        <Route path="/confirmar-senha/:token" element={<ResetPassword />} />
+      </Routes>
+    </>
+  )
+}
+
 function App() {
   return (
     <>
       <div className="min-h-screen bg-gray-50">
         <BrowserRouter>
-          <Header></Header>
-          <BannerHeader></BannerHeader>
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/register" element={<Register />} />
-            <Route path="/marketplace" element={<Marketplace />} />
-            <Route path="/search" element={<SearchProfessionals />} />
-            <Route path="/quote-product" element={<QuoteProducts />} />
-            <Route path="/privacy" element={<PrivacyPolicy />} />
-            <Route path="/checkout" element={<Checkout />} />
-            <Route path="/checkout-unlock" element={<CheckoutUnlock />} />
-
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/search-results" element={<SearchResults />} />
-            <Route path="/professional-panel" element={<ProfessionalPanel />} />
-            <Route path="/product-categories-admin" element={<ProductCategoriesAdmin />} />
-            <Route path="/confirmar-senha/:token" element={<ResetPassword />} />
-          </Routes>
+          <AppContent />
         </BrowserRouter>
       </div>
       <div>

--- a/frontend/src/components/PrivacyPolicyCheckbox.tsx
+++ b/frontend/src/components/PrivacyPolicyCheckbox.tsx
@@ -1,19 +1,48 @@
-import { Link } from "react-router-dom"
-import type { ChangeEvent } from "react"
+import type { ChangeEvent, MouseEvent } from "react"
+import { useLocation, useNavigate } from "react-router-dom"
+import {
+  BudgetFormDraftKey,
+  saveBudgetFormDraft,
+} from "../utils/budgetFormDraft"
 
 interface PrivacyPolicyCheckboxProps {
   checked: boolean
   onChange: (checked: boolean) => void
   id?: string
+  formDraftKey?: BudgetFormDraftKey
+  getFormDraft?: () => Record<string, unknown>
 }
 
 function PrivacyPolicyCheckbox({
   checked,
   onChange,
   id = "privacy-policy-accept",
+  formDraftKey,
+  getFormDraft,
 }: PrivacyPolicyCheckboxProps) {
+  const navigate = useNavigate()
+  const location = useLocation()
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange(event.target.checked)
+  }
+
+  const handlePrivacyClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    if (formDraftKey && getFormDraft) {
+      saveBudgetFormDraft(formDraftKey, getFormDraft())
+    }
+
+    navigate("/privacy", {
+      state: {
+        returnTo: `${location.pathname}${location.search}`,
+        returnLabel: "Voltar ao formulário",
+        formDraftKey,
+        returnState: location.state,
+      },
+    })
   }
 
   return (
@@ -32,14 +61,13 @@ function PrivacyPolicyCheckbox({
       />
       <span>
         Li e concordo com a{" "}
-        <Link
-          to="/privacy"
-          target="_blank"
-          rel="noopener noreferrer"
+        <button
+          type="button"
+          onClick={handlePrivacyClick}
           className="text-blue-600 hover:text-blue-800 underline"
         >
           Política de Privacidade
-        </Link>
+        </button>
       </span>
     </label>
   )

--- a/frontend/src/components/PrivacyPolicyCheckbox.tsx
+++ b/frontend/src/components/PrivacyPolicyCheckbox.tsx
@@ -1,0 +1,48 @@
+import { Link } from "react-router-dom"
+import type { ChangeEvent } from "react"
+
+interface PrivacyPolicyCheckboxProps {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  id?: string
+}
+
+function PrivacyPolicyCheckbox({
+  checked,
+  onChange,
+  id = "privacy-policy-accept",
+}: PrivacyPolicyCheckboxProps) {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.checked)
+  }
+
+  return (
+    <label
+      htmlFor={id}
+      className="flex items-start gap-3 cursor-pointer text-sm text-gray-600"
+    >
+      <input
+        type="checkbox"
+        id={id}
+        checked={checked}
+        onChange={handleChange}
+        required
+        className="mt-1 w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+        aria-label="Aceitar política de privacidade"
+      />
+      <span>
+        Li e concordo com a{" "}
+        <Link
+          to="/privacy"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:text-blue-800 underline"
+        >
+          Política de Privacidade
+        </Link>
+      </span>
+    </label>
+  )
+}
+
+export default PrivacyPolicyCheckbox

--- a/frontend/src/hooks/usePageViewTracker.ts
+++ b/frontend/src/hooks/usePageViewTracker.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react"
+import { useLocation } from "react-router-dom"
+import { PageViewService } from "../services/PageViewService"
+
+const isAdminLoggedIn = (): boolean =>
+  localStorage.getItem("profile") === "admin" &&
+  !!localStorage.getItem("token")
+
+export const usePageViewTracker = () => {
+  const location = useLocation()
+
+  useEffect(() => {
+    if (isAdminLoggedIn()) return
+
+    const path = location.pathname || "/"
+    PageViewService.trackPageView(path).catch(() => {})
+  }, [location.pathname])
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -30,6 +30,7 @@ import LoadingText from "../components/LoadingText";
 import DashboardProfessions from "./DashboardProfissions";
 import DashboardRegions from "./DashboardRegions";
 import ProductCategoriesAdmin from "./ProductCategoriesAdmin";
+import DashboardPageViews from "./DashboardPageViews";
 
 function Dashboard() {
 
@@ -206,6 +207,7 @@ function Dashboard() {
     { id: "professions", label: "Profissões" },
     { id: "regions", label: "Regiões" },
     { id: "categoryProducts", label: "Categorias de produtos" },
+    { id: "pageViews", label: "Acessos às Páginas" },
   ];
 
   const renderDashboard = () => {
@@ -775,6 +777,7 @@ function Dashboard() {
             {selectedDashboardSection === "categoryProducts" && (
               <ProductCategoriesAdmin />
             )}
+            {selectedDashboardSection === "pageViews" && <DashboardPageViews />}
           </div>
         </div>
       </>

--- a/frontend/src/pages/DashboardPageViews.tsx
+++ b/frontend/src/pages/DashboardPageViews.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react"
+import { BarChart3 } from "lucide-react"
+import { IPageView, PageViewService } from "../services/PageViewService"
+
+function DashboardPageViews() {
+  const [pageViews, setPageViews] = useState<IPageView[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchPageViews = async () => {
+      try {
+        const response = await PageViewService.getPageViews()
+        if (response.status === 200) {
+          const sorted = [...response.data].sort((a, b) => b.count - a.count)
+          setPageViews(sorted)
+        }
+      } catch (error) {
+        console.error("Erro ao buscar acessos às páginas:", error)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchPageViews()
+  }, [])
+
+  if (isLoading) {
+    return <p className="text-gray-600">Carregando acessos...</p>
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-3 bg-indigo-100 rounded-lg">
+          <BarChart3 className="w-6 h-6 text-indigo-600" />
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">
+            Acessos por Página
+          </h3>
+          <p className="text-sm text-gray-600">
+            Páginas com mais visitas podem indicar gargalos ou oportunidades.
+            Acessos de admin logado não são contabilizados.
+          </p>
+        </div>
+      </div>
+
+      {pageViews.length === 0 ? (
+        <p className="text-gray-500">Nenhum acesso registrado ainda.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full table-auto text-sm">
+            <thead className="bg-gray-50">
+              <tr className="border-b border-gray-200">
+                <th className="px-4 py-3 text-left font-medium text-gray-500">
+                  Página
+                </th>
+                <th className="px-4 py-3 text-right font-medium text-gray-500">
+                  Acessos
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {pageViews.map((pageView) => (
+                <tr key={pageView.id} className="border-b border-gray-100">
+                  <td className="px-4 py-3 text-gray-900 font-mono">
+                    {pageView.path}
+                  </td>
+                  <td className="px-4 py-3 text-right text-gray-900 font-semibold">
+                    {pageView.count.toLocaleString("pt-BR")}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default DashboardPageViews

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -1,18 +1,54 @@
-import React from "react";
-import { ArrowLeft } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { ArrowLeft } from "lucide-react"
+import { useLocation, useNavigate } from "react-router-dom"
 
-function PrivacyPolicy() {
-  const navigate = useNavigate();
+interface PrivacyPolicyLocationState {
+  returnTo?: string
+  returnLabel?: string
+  formDraftKey?: string
+  returnState?: unknown
+  restoreFormDraft?: string
+}
+
+interface PrivacyPolicyProps {
+  onBack?: () => void
+}
+
+function PrivacyPolicy({ onBack }: PrivacyPolicyProps) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const navigationState = location.state as PrivacyPolicyLocationState | null
+  const returnTo = navigationState?.returnTo
+  const returnLabel =
+    navigationState?.returnLabel ?? "Voltar para página inicial"
+
+  const handleBack = () => {
+    if (onBack) {
+      onBack()
+      return
+    }
+    if (returnTo) {
+      navigate(returnTo, {
+        state: {
+          ...((navigationState?.returnState as object) ?? {}),
+          restoreFormDraft: navigationState?.formDraftKey,
+        },
+      })
+      return
+    }
+    navigate("/")
+  }
+
   return (
     <div className="min-h-screen bg-gray-50 py-12">
       <div className="max-w-4xl mx-auto px-4">
         <button
-          onClick={() => navigate("/")}
+          type="button"
+          onClick={handleBack}
           className="flex items-center gap-2 text-gray-600 hover:text-blue-600 mb-8 transition-colors"
+          aria-label={returnLabel}
         >
           <ArrowLeft className="w-5 h-5" />
-          Voltar para página inicial
+          {returnLabel}
         </button>
 
         <div className="bg-white rounded-xl shadow-xl p-8">

--- a/frontend/src/pages/QuoteProducts.tsx
+++ b/frontend/src/pages/QuoteProducts.tsx
@@ -15,7 +15,7 @@ import { BannerService } from "../services/BannerService";
 import InputMask from "react-input-mask";
 import { ProductCategoryService, RegionService } from "../services";
 import { StoreService } from "../services/StoreService";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import Select from "react-select";
 import {
   IBannerSearchProfessionals,
@@ -29,6 +29,11 @@ import Swal from "sweetalert2";
 import { BudgetService } from "../services/Budget";
 import { ArrowLeft } from "lucide-react";
 import PrivacyPolicyCheckbox from "../components/PrivacyPolicyCheckbox";
+import {
+  BUDGET_FORM_DRAFT_KEYS,
+  clearBudgetFormDraft,
+  loadBudgetFormDraft,
+} from "../utils/budgetFormDraft";
 
 interface SearchProductsProps {
   onNavigate?: (page: string) => void;
@@ -37,6 +42,15 @@ interface FormData {
   name: string;
   phone: string;
   message: string;
+}
+
+interface QuoteProductsFormDraft {
+  formData: FormData;
+  privacyAccepted: boolean;
+  selectedState: string;
+  selectedCity: string;
+  selectedCategoryProduct: string;
+  selectedSubcategories: number[];
 }
 
 // URL_IMAGES_WEB do .env
@@ -68,6 +82,7 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
   const [imageModal, setImageModal] =
     useState<IBannerSearchProfessionals | null>(null);
   const navigate = useNavigate();
+  const location = useLocation();
 
   // Função para gerar número aleatório
   const gerarNumeroAleatorio = (min: number, max: number): number => {
@@ -136,6 +151,39 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
     fetchData();
   }, [selectedState]);
 
+  useEffect(() => {
+    if (
+      location.state?.restoreFormDraft !==
+      BUDGET_FORM_DRAFT_KEYS.quoteProducts
+    ) {
+      return;
+    }
+
+    const draft = loadBudgetFormDraft<QuoteProductsFormDraft>(
+      BUDGET_FORM_DRAFT_KEYS.quoteProducts
+    );
+    if (!draft) return;
+
+    setFormData(draft.formData);
+    setPrivacyAccepted(draft.privacyAccepted);
+    setSelectedState(draft.selectedState);
+    setSelectedCity(draft.selectedCity);
+    setSelectedCategoryProduct(draft.selectedCategoryProduct);
+    setSelectedSubcategories(draft.selectedSubcategories);
+
+    const { restoreFormDraft: _, ...preservedState } =
+      (location.state as Record<string, unknown>) ?? {};
+    navigate(`${location.pathname}${location.search}`, {
+      replace: true,
+      state: preservedState,
+    });
+  }, [
+    location.state?.restoreFormDraft,
+    location.pathname,
+    location.search,
+    navigate,
+  ]);
+
   // Limpa subcategorias selecionadas quando mudar a categoria
   useEffect(() => {
     setSelectedSubcategories([]);
@@ -169,6 +217,7 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
   };
   
   const cleanForm = () => {
+    clearBudgetFormDraft(BUDGET_FORM_DRAFT_KEYS.quoteProducts);
     setFormData({
       name: "",
       phone: "",
@@ -723,6 +772,15 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
                 <PrivacyPolicyCheckbox
                   checked={privacyAccepted}
                   onChange={setPrivacyAccepted}
+                  formDraftKey={BUDGET_FORM_DRAFT_KEYS.quoteProducts}
+                  getFormDraft={() => ({
+                    formData,
+                    privacyAccepted,
+                    selectedState,
+                    selectedCity,
+                    selectedCategoryProduct,
+                    selectedSubcategories,
+                  })}
                 />
 
                 <button

--- a/frontend/src/pages/QuoteProducts.tsx
+++ b/frontend/src/pages/QuoteProducts.tsx
@@ -5,7 +5,6 @@ import {
   HardHat,
   MessageSquare,
   User,
-  Mail,
   Phone,
 } from "lucide-react";
 import { states } from "../data";
@@ -29,17 +28,15 @@ import { ICategoryProduct } from "../interfaces/ICategoryProduct";
 import Swal from "sweetalert2";
 import { BudgetService } from "../services/Budget";
 import { ArrowLeft } from "lucide-react";
+import PrivacyPolicyCheckbox from "../components/PrivacyPolicyCheckbox";
 
 interface SearchProductsProps {
   onNavigate?: (page: string) => void;
 }
 interface FormData {
   name: string;
-  email: string;
   phone: string;
   message: string;
-  clientId: number;
-  cityId: number;
 }
 
 // URL_IMAGES_WEB do .env
@@ -48,12 +45,10 @@ const URL_IMAGES_WEB = import.meta.env.VITE_URL_IMAGES_WEB;
 function QuoteProducts({ onNavigate }: SearchProductsProps) {
   const [formData, setFormData] = useState<FormData>({
     name: "",
-    email: "",
     phone: "",
     message: "",
-    clientId: 0,
-    cityId: 0,
   });
+  const [privacyAccepted, setPrivacyAccepted] = useState(false);
   const [selectedState, setSelectedState] = useState<string>("");
   const [selectedCity, setSelectedCity] = useState<string>("");
   const [selectedCategoryProduct, setSelectedCategoryProduct] =
@@ -176,12 +171,10 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
   const cleanForm = () => {
     setFormData({
       name: "",
-      email: "",
       phone: "",
       message: "",
-      clientId: 0,
-      cityId: 0,
     });
+    setPrivacyAccepted(false);
     setSelectedState("");
     setSelectedCity("");
     setcitiesByState([]);
@@ -192,7 +185,19 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
 
   const handleFormSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const quoteMessage= "Preciso dos preços destes produtos, os itens selecionados: "
+
+    if (!privacyAccepted) {
+      Swal.fire({
+        position: "center",
+        icon: "warning",
+        title: "Aceite a política de privacidade",
+        text: "É necessário aceitar a política de privacidade para continuar.",
+        showConfirmButton: true,
+      });
+      return;
+    }
+
+    const quoteMessage = "Preciso dos preços destes produtos, os itens selecionados: "
     const currentFormData = { ...formData };
     const currentCities = [...citiesByState];
     const currentSelectedCity = selectedCity;
@@ -219,12 +224,11 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
 
     const budget: IBudget = {
       name: currentFormData.name,
-      email: currentFormData.email,
+      email: "",
       telephone: currentFormData.phone,
       storesId: [],
-      description: quoteMessage+resultSubCategories,
-      // description: "Preciso dos preços destes produtos, os itens selecionados",
-      termResponsabilityAccepted: true,
+      description: `${currentFormData.message}\n\n${quoteMessage}${resultSubCategories}`,
+      termResponsabilityAccepted: privacyAccepted,
       cityId: parseInt(currentSelectedCity),
       professionalsId: [],
       approved: false,
@@ -650,12 +654,12 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
                 Suas Informações de Contato
               </h3>
               <form onSubmit={handleFormSubmit} className="space-y-4">
-                {/* <div>
+                <div>
                   <label
                     htmlFor="name"
                     className="block text-sm font-medium text-gray-700 mb-1"
                   >
-                    Nome Completo *
+                    Nome Completo
                   </label>
 
                   <div className="relative">
@@ -666,19 +670,18 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
                       name="name"
                       value={formData.name}
                       onChange={handleInputChange}
-                      // disabled={isClient}
                       required
-                      className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500  disabled:bg-gray-50"
+                      className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
                   </div>
-                </div> */}
+                </div>
 
                 <div>
                   <label
                     htmlFor="phone"
                     className="block text-sm font-medium text-gray-700 mb-1"
                   >
-                    WhatsApp *
+                    Telefone
                   </label>
                   <div className="relative">
                     <Phone className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
@@ -689,40 +692,49 @@ function QuoteProducts({ onNavigate }: SearchProductsProps) {
                       name="phone"
                       value={formData.phone}
                       onChange={handleInputChange}
-                      // disabled={isClient}
                       required
-                      className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50"
+                      className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     />
                   </div>
                 </div>
-                 <div>
+
+                <div>
                   <label
-                    htmlFor="email"
+                    htmlFor="message"
                     className="block text-sm font-medium text-gray-700 mb-1"
                   >
-                    Email (Opcional)
+                    Descrição do orçamento
                   </label>
                   <div className="relative">
-                    <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
-                    <input
-                      type="email"
-                      id="email"
-                      name="email"
-                      value={formData.email}
+                    <MessageSquare className="absolute left-3 top-3 text-gray-400 w-5 h-5" />
+                    <textarea
+                      id="message"
+                      name="message"
+                      value={formData.message}
                       onChange={handleInputChange}
-                      // disabled={isClient}
-                      className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50"
+                      required
+                      rows={4}
+                      className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      placeholder="Descreva o que você precisa..."
                     />
                   </div>
-                </div> 
+                </div>
+
+                <PrivacyPolicyCheckbox
+                  checked={privacyAccepted}
+                  onChange={setPrivacyAccepted}
+                />
+
                 <button
-                  // onClick={handleOpenModal}
                   type="submit"
                   disabled={
                     !selectedState ||
                     !selectedCity ||
                     selectedSubcategories.length === 0 ||
-                    formData.phone === ""
+                    formData.name === "" ||
+                    formData.phone === "" ||
+                    formData.message === "" ||
+                    !privacyAccepted
                   }
                   className="mt-8 w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-medium hover:bg-blue-700 transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
                 >

--- a/frontend/src/pages/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults.tsx
@@ -54,6 +54,7 @@ interface SearchResultsFormDraft {
   privacyAccepted: boolean;
   isBulkRequest: boolean;
   selectedProfessionalOid: number | null;
+  professionalLabel: string | null;
 }
 
 // interface SearchResultsProps {
@@ -94,6 +95,9 @@ function SearchResults() {
   const [showContactForm, setShowContactForm] = useState(false);
   const [showProfessionalSearch, setShowProfessionalSearch] = useState(true);
   const [privacyAccepted, setPrivacyAccepted] = useState(false);
+  const [restoredProfessionalLabel, setRestoredProfessionalLabel] = useState<
+    string | null
+  >(null);
   const [searchCityId, setSearchCityId] = useState<number>(0);
   const [selectedProfessional, setSelectedProfessional] =
     useState<IProfissional | null>(null);
@@ -197,6 +201,35 @@ function SearchResults() {
     fetchData();
   }, []);
 
+  const clearRestoreNavigationState = () => {
+    const { restoreFormDraft: _, ...preservedState } =
+      (location.state as Record<string, unknown>) ?? {};
+    navigate(`${location.pathname}${location.search}`, {
+      replace: true,
+      state: preservedState,
+    });
+  };
+
+  const getProfessionalLabel = (
+    professional: IProfissional | null
+  ): string | null => {
+    if (!professional) return null;
+    if (professional.nome) return professional.nome;
+    const cityName = professional.cidade?.nome;
+    const cityUf = professional.cidade?.uf;
+    if (cityName && cityUf) return `${cityName}, ${cityUf}`;
+    return null;
+  };
+
+  const getContactFormSubtitle = (): string => {
+    if (isBulkRequest) {
+      return `Enviar para ${professionals.length} profissionais`;
+    }
+    const label = getProfessionalLabel(selectedProfessional);
+    if (label) return label;
+    return restoredProfessionalLabel ?? "";
+  };
+
   useEffect(() => {
     if (
       location.state?.restoreFormDraft !==
@@ -213,25 +246,34 @@ function SearchResults() {
     setFormData(draft.formData);
     setPrivacyAccepted(draft.privacyAccepted);
     setIsBulkRequest(draft.isBulkRequest);
+    setRestoredProfessionalLabel(draft.professionalLabel);
     setShowContactForm(true);
     setShowProfessionalSearch(false);
+
+    if (draft.isBulkRequest) {
+      setSelectedProfessional(null);
+      clearRestoreNavigationState();
+      return;
+    }
+
+    if (draft.selectedProfessionalOid && professionals.length === 0) {
+      return;
+    }
 
     if (draft.selectedProfessionalOid && professionals.length > 0) {
       const professional = professionals.find(
         (item) => item.oid === draft.selectedProfessionalOid
       );
       setSelectedProfessional(professional ?? null);
+      if (professional) {
+        setRestoredProfessionalLabel(getProfessionalLabel(professional));
+      }
     } else {
       setSelectedProfessional(null);
     }
 
-    const { restoreFormDraft: _, ...preservedState } =
-      (location.state as Record<string, unknown>) ?? {};
-    navigate(`${location.pathname}${location.search}`, {
-      replace: true,
-      state: preservedState,
-    });
-  }, [location.state?.restoreFormDraft, professionals, location.pathname, location.search, navigate]);
+    clearRestoreNavigationState();
+  }, [location.state?.restoreFormDraft, professionals]);
 
   const openQuoteForm = (
     professional: IProfissional | null = null,
@@ -240,6 +282,7 @@ function SearchResults() {
     setSelectedProfessional(professional);
     setIsBulkRequest(bulk);
     setPrivacyAccepted(false);
+    setRestoredProfessionalLabel(null);
     setShowProfessionalSearch(false);
     setShowContactForm(true);
   };
@@ -298,6 +341,7 @@ function SearchResults() {
         message: "",
       });
       setPrivacyAccepted(false);
+      setRestoredProfessionalLabel(null);
 
       Swal.fire({
         position: "center",
@@ -367,11 +411,7 @@ function SearchResults() {
                       Solicitar Orçamento
                     </h3>
                     <p className="text-sm text-gray-600">
-                      {isBulkRequest
-                        ? `Enviar para ${professionals.length} profissionais`
-                        : selectedProfessional && selectedProfessional.nome
-                        ? `${selectedProfessional.nome}`
-                        : `${selectedProfessional?.cidade.nome}, ${selectedProfessional?.cidade.uf}`}
+                      {getContactFormSubtitle()}
                     </p>
                   </div>
                 </div>
@@ -466,6 +506,9 @@ function SearchResults() {
                     privacyAccepted,
                     isBulkRequest,
                     selectedProfessionalOid: selectedProfessional?.oid ?? null,
+                    professionalLabel: isBulkRequest
+                      ? null
+                      : getProfessionalLabel(selectedProfessional),
                   })}
                 />
 

--- a/frontend/src/pages/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults.tsx
@@ -3,7 +3,6 @@ import {
   ArrowLeft,
   // Star,
   Phone,
-  Mail,
   User,
   MessageSquare,
   X,
@@ -12,30 +11,18 @@ import {
   ShieldCheck,
   Building2,
   MapPin,
-  Brain,
-  Check,
-  BadgeCheck,
   Send,
-  // Crown,
-  // Trophy,
-  // Diamond,
-  // Award,
-  // BadgeCheck,
+  BadgeCheck,
 } from "lucide-react";
 import InputMask from "react-input-mask";
 import { BudgetService } from "../services/Budget";
 import Swal from "sweetalert2";
-import Login from "./Login";
-import { states } from "../data";
 import Navigation from "../components/Navigation";
-import { ClientService } from "../services/ClientService";
-import { CityService } from "../services/CityService";
 import { ProfessionalService } from "../services/ProfessionalService";
 import { useLocation, useNavigate } from "react-router-dom";
-import Select from "react-select";
+import PrivacyPolicyCheckbox from "../components/PrivacyPolicyCheckbox";
 import {
   IBudget,
-  ICitySearchProfessionals,
   IProfissional,
 } from "../interfaces";
 //import { useNavigate } from "react-router-dom";
@@ -53,11 +40,8 @@ interface Professional {
 
 interface FormData {
   name: string;
-  email: string;
   phone: string;
   message: string;
-  clientId: number;
-  cityId: number;
 }
 
 // interface SearchResultsProps {
@@ -95,34 +79,23 @@ function SearchResults() {
   professionals,
   onNewSearch,
 }: SearchResultsProps*/
-  const [selectedState, setSelectedState] = useState<string>("");
-  const [selectedCity, setSelectedCity] = useState<string>("");
-  const [citiesByState, setcitiesByState] = useState<
-    ICitySearchProfessionals[]
-  >([]);
-  const [showLGPDTerms, setShowLGPDTerms] = useState(false);
-  const [modalInfoProfissional, setModalInfoProfissional] = useState(false);
-  const [showExpandedImage, setShowExpandedImage] = useState(false);
-  // const [selectedProfessional, setProfessionalForModal] = useState<IProfissional | null>(null);
-  // const [showLogin, setShowLogin] = useState(false);
   const [showContactForm, setShowContactForm] = useState(false);
   const [showProfessionalSearch, setShowProfessionalSearch] = useState(true);
+  const [privacyAccepted, setPrivacyAccepted] = useState(false);
+  const [searchCityId, setSearchCityId] = useState<number>(0);
   const [selectedProfessional, setSelectedProfessional] =
     useState<IProfissional | null>(null);
   const [isBulkRequest, setIsBulkRequest] = useState(false);
   const [formData, setFormData] = useState<FormData>({
     name: "",
-    email: "",
     phone: "",
     message: "",
-    clientId: 0,
-    cityId: 0,
   });
 
   const [showPhoneNumbers, setShowPhoneNumbers] = useState<boolean>(false);
-  const [showErrorMessage, setShowErrorMessage] = useState<boolean>(false);
+  const [modalInfoProfissional, setModalInfoProfissional] = useState(false);
+  const [showExpandedImage, setShowExpandedImage] = useState(false);
   const [currentPage, setCurrentPage] = useState<string>("search-results");
-  // const [isClient, setIsClient] = useState<boolean>(false);
   const [professionals, setProfessionals] = useState<IProfissional[]>([]);
   // const [profession, setProfession] = useState<string>("");
   const navigate = useNavigate();
@@ -189,8 +162,12 @@ function SearchResults() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const selectedCity = location.state.selectedCity;
-      const selectedProfessional = location.state.selectedProfessional;
+      const selectedCity = location.state?.selectedCity;
+      const selectedProfessional = location.state?.selectedProfessional;
+
+      if (selectedCity) {
+        setSearchCityId(parseInt(selectedCity));
+      }
 
       const res = await ProfessionalService.getProfessionalsRandomPublic({
         professionId: parseInt(selectedProfessional),
@@ -208,78 +185,42 @@ function SearchResults() {
     fetchData();
   }, []);
 
-  // Busca cidades e profissões ao mudar estado
-  useEffect(() => {
-    setSelectedCity("");
-    const fetchData = async () => {
-      if (!selectedState) return;
-
-      try {
-        const citiesRes = await CityService.citiesByStatePublic({
-          uf: selectedState,
-        });
-        if (citiesRes.status === 200) setcitiesByState(citiesRes.data);
-      } catch (error) {
-        console.error("Erro ao buscar cidades ou profissões:", error);
-      }
-    };
-
-    fetchData();
-  }, [selectedState]);
-
-  const handleRequestQuote = async (
+  const openQuoteForm = (
     professional: IProfissional | null = null,
     bulk = false
   ) => {
-    // if (localStorage.getItem("id") != null) {
-    setSelectedProfessional(professional as IProfissional | null);
+    setSelectedProfessional(professional);
     setIsBulkRequest(bulk);
-    // setShowLGPDTerms(true);
-    // const result = await ClientService.getClientbyID(
-    //   parseInt(localStorage.getItem("id") ?? "0")
-    // );
-    // console.log(result);
-
-    // if ((result.status == 200)) {
-    //   const json = await result.data;
-    //   formData.name = json.nome;
-    //   formData.email = json.email;
-    //   formData.phone = json.telefone;
-    //   formData.clientId = json.oid;
-    // }
-    // setIsClient(true);
-    // } else {
+    setPrivacyAccepted(false);
     setShowProfessionalSearch(false);
-    // setShowLogin(true);
-    //      setCurrentPage("login");
-    //onNavigate && onNavigate("login");
-  };
-
-  const handleAcceptTerms = () => {
-    setShowLGPDTerms(false);
     setShowContactForm(true);
-    // console.log("Selected_Professionals");
-    // console.log(selectedProfessional);
-    // console.log("------");
   };
 
-  const handleRejectTerms = () => {
-    setShowLGPDTerms(false);
-    setShowErrorMessage(true);
-    setSelectedProfessional(null);
-    setIsBulkRequest(false);
-    setTimeout(() => {
-      setShowErrorMessage(false);
-    }, 3000);
+  const getBudgetCityId = (): number => {
+    if (searchCityId > 0) return searchCityId;
+    if (selectedProfessional?.cidade?.oid) return selectedProfessional.cidade.oid;
+    if (professionals.length > 0 && professionals[0].cidade?.oid) {
+      return professionals[0].cidade.oid;
+    }
+    return 0;
   };
 
   const handleFormSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // console.log("Form submitted:", formData);
-    // console.log(selectedProfessional);
+
+    if (!privacyAccepted) {
+      Swal.fire({
+        position: "center",
+        icon: "warning",
+        title: "Aceite a política de privacidade",
+        text: "É necessário aceitar a política de privacidade para continuar.",
+        showConfirmButton: true,
+      });
+      return;
+    }
+
     let profs: string[];
     if (selectedProfessional == null) {
-      // console.log(professionals);
       profs = professionals.map((prof) => prof.oid.toString());
     } else {
       profs = [selectedProfessional.oid.toString()];
@@ -287,16 +228,13 @@ function SearchResults() {
 
     const budget: IBudget = {
       name: formData.name,
-      email: formData.email,
+      email: "",
       telephone: formData.phone,
-      // clientId: formData.clientId,
       description: formData.message,
-      termResponsabilityAccepted: true,
-      cityId: parseInt(selectedCity),
+      termResponsabilityAccepted: privacyAccepted,
+      cityId: getBudgetCityId(),
       professionalsId: [],
     };
-    // adicionar na lista o id do profissional selecionado
-    //  profs é um array de string, preciso converter para number
     budget.professionalsId = profs.map(Number);
 
     const postReturn = await BudgetService.saveBudget(budget);
@@ -304,22 +242,14 @@ function SearchResults() {
     if (postReturn.status == 200) {
       setShowContactForm(false);
       setShowProfessionalSearch(true);
-      //setShowPhoneNumbers(true);
 
-      // Limpar os campos do formulário após envio bem-sucedido
       setFormData({
         name: "",
-        email: "",
         phone: "",
         message: "",
-        clientId: 0,
-        cityId: 0,
       });
-      setSelectedState("");
-      setSelectedCity("");
-      setcitiesByState([]);
+      setPrivacyAccepted(false);
 
-      // Mostrar mensagem de sucesso com SweetAlert2
       Swal.fire({
         position: "center",
         icon: "success",
@@ -349,13 +279,6 @@ function SearchResults() {
     }));
   };
 
-    const cityOptions = citiesByState.map(
-    (city: ICitySearchProfessionals) => ({
-      value: city.id,
-      label: city.name,
-    })
-  );
-
   return (
     <div className="min-h-screen bg-gray-50 py-12">
       <Navigation
@@ -366,138 +289,6 @@ function SearchResults() {
           throw new Error("Function not implemented.");
         }}
       />
-      {/* Success Message - Removido pois agora usa SweetAlert2 */}
-      {/* Error Message */}
-      {showErrorMessage && (
-        <div className="fixed top-4 right-4 bg-red-600 text-white px-6 py-3 rounded-lg shadow-lg z-50 animate-slide-up">
-          <div className="flex items-center gap-2">
-            <Info className="w-5 h-5" />
-            <p>
-              É necessário aceitar os termos para prosseguir com a solicitação.
-            </p>
-          </div>
-        </div>
-      )}
-      {/* LGPD Terms Modal */}
-      {/* {showLogin && (
-        /*
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <div className="p-6">
-              <button
-                onClick={() => {
-                  setShowLogin(false);
-                }}
-                className="text-gray-400 hover:text-gray-600"
-              >
-                <X className="w-5 h-5" />
-              </button>
-              <Login onNavigate="home"></Login>
-            </div>
-          </div>
-        </div>
-
-        // <Login onNavigate={setCurrentPage}></Login>
-      )} 
-      */}
-      {/* LGPD Terms Modal */}
-      {showLGPDTerms && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <div className="p-6">
-              <div className="flex justify-between items-start mb-4">
-                <h3 className="text-xl font-bold text-gray-900">
-                  Termo de Responsabilidade e Isenção de Responsabilidade por
-                  Dados Fornecidos - LGPD
-                </h3>
-                <button
-                  onClick={handleRejectTerms}
-                  className="text-gray-400 hover:text-gray-600"
-                >
-                  <X className="w-5 h-5" />
-                </button>
-              </div>
-
-              <div className="prose prose-sm max-w-none text-gray-600 space-y-4">
-                <p>
-                  Por favor, leia atentamente o seguinte termo antes de
-                  prosseguir:
-                </p>
-
-                <p>
-                  Eu, o Cliente, ao utilizar os serviços fornecidos pela plataforma digital HASSIS CONECTA, reconheço e concordo com os termos e condições estabelecidos neste documento.
-                </p>
-
-                <h4 className="font-semibold text-gray-900">
-                  Responsabilidade pelos Dados Fornecidos:
-                </h4>
-                <p>
-                  Eu reconheço e concordo que sou totalmente responsável por quaisquer dados pessoais, informações ou conteúdos que eu solicite, receba ou de qualquer forma obtenha através da plataforma HASSIS CONECTA.
-                </p>
-
-                <h4 className="font-semibold text-gray-900">
-                  Isenção de Responsabilidade da Plataforma:
-                </h4>
-                <p>
-                  A responsabilidade pela proteção e tratamento adequado dos
-                  dados pessoais é exclusivamente do Cliente.
-                </p>
-
-                <h4 className="font-semibold text-gray-900">
-                  Finalidade e Consentimento:
-                </h4>
-                <p>
-                  Eu reconheço que a HASSIS CONECTA pode coletar, armazenar e utilizar meus dados pessoais conforme necessário para a prestação de serviços ou cumprimento de obrigações contratuais, desde que em conformidade com as disposições da LGPD e mediante consentimento explícito do titular dos dados, quando aplicável.
-                </p>
-
-                <h4 className="font-semibold text-gray-900">
-                  Segurança dos Dados:
-                </h4>
-                <p>
-                  A HASSIS CONECTA adota medidas técnicas e organizacionais adequadas para proteger os dados pessoais contra acesso não autorizado, uso indevido, divulgação, alteração e destruição não autorizados, em conformidade com as disposições da LGPD.
-                </p>
-
-                <h4 className="font-semibold text-gray-900">
-                  Direitos dos Titulares dos Dados:
-                </h4>
-                <p>
-                  Eu reconheço e concordo em respeitar os direitos dos titulares dos dados, conforme previsto na LGPD, incluindo o direito de acesso, retificação, exclusão, anonimização, portabilidade e revogação do consentimento.
-                </p>
-
-                <h4 className="font-semibold text-gray-900">Indenização:</h4>
-                <p>
-                  Eu concordo em indenizar e isentar a HASSIS CONECTA, seus diretores, funcionários e agentes de qualquer responsabilidade, perda, reclamação ou despesa (incluindo honorários advocatícios razoáveis) decorrentes ou relacionados com o tratamento de dados pessoais pelo Cliente ou com o uso da plataforma.
-                </p>
-
-                <p>
-                  Ao clicar no botão "Concordo", eu confirmo que li, entendi e concordo com os termos e condições estabelecidos neste Termo de Responsabilidade e Isenção de Responsabilidade por Dados Fornecidos.
-                </p>
-              </div>
-
-              <div className="mt-6 flex justify-end gap-4">
-                <button
-                  onClick={handleRejectTerms}
-                  className="px-4 py-2 text-gray-600 hover:text-gray-900"
-                >
-                  Recusar
-                </button>
-                <button
-                  onClick={() => {
-                    handleRequestQuote(
-                      selectedProfessional,
-                      selectedProfessional == null
-                    );
-                    handleAcceptTerms();
-                  }}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-                >
-                  Concordo
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
       {/* Contact Form Modal */}
       {showContactForm && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
@@ -574,28 +365,6 @@ function SearchResults() {
 
                 <div>
                   <label
-                    htmlFor="email"
-                    className="block text-sm font-medium text-gray-700 mb-1"
-                  >
-                    Email
-                  </label>
-                  <div className="relative">
-                    <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
-                    <input
-                      type="email"
-                      id="email"
-                      name="email"
-                      value={formData.email}
-                      onChange={handleInputChange}
-                      // disabled={isClient}
-                      required
-                      className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50"
-                    />
-                  </div>
-                </div>
-
-                <div>
-                  <label
                     htmlFor="phone"
                     className="block text-sm font-medium text-gray-700 mb-1"
                   >
@@ -618,74 +387,11 @@ function SearchResults() {
                 </div>
 
                 <div>
-                  {/* Estado */}
-                  <div>
-                    <label
-                      htmlFor="state"
-                      className="block text-sm font-medium text-gray-700 mb-1"
-                    >
-                      Estado
-                    </label>
-                    <div className="relative">
-                      <Building2 className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5" />
-                      <select
-                        id="state"
-                        value={selectedState}
-                        onChange={(e) => setSelectedState(e.target.value)}
-                        className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 appearance-none bg-white mb-4"
-                      >
-                        <option value="">Selecione o estado</option>
-                        {states.map((state) => (
-                          <option key={state.id} value={state.id}>
-                            {state.name}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  </div>
-
-                  {/* Cidade */}
-                  <div>
-                    <label
-                      htmlFor="city"
-                      className="block text-sm font-medium text-gray-700 mb-1"
-                    >
-                      Cidade
-                    </label>
-                    <div className="relative">
-                       <MapPin className="absolute left-3 top-3 text-gray-400 w-5 h-5 z-10" />
-                      <Select
-                          options={cityOptions}
-                          value={
-                            cityOptions.find(
-                              (option) => option.value.toString() === selectedCity
-                            ) || null
-                          }
-                          onChange={(selectedOption) =>
-                            setSelectedCity(selectedOption?.value.toString() || "")
-                          }
-                          isDisabled={!selectedState}
-                          placeholder="Digite ou selecione a cidade"
-                          isSearchable
-                          className="text-sm"
-                          styles={{
-                            control: (base) => ({
-                              ...base,
-                              minHeight: "42px",
-                              paddingLeft: "30px",
-                            }),
-                          }}
-                        />
-                    </div>
-                  </div>
-                </div>
-
-                <div>
                   <label
                     htmlFor="message"
                     className="block text-sm font-medium text-gray-700 mb-1"
                   >
-                    Descreva com detalhes o serviço
+                    Descrição do orçamento
                   </label>
                   <div className="relative">
                     <MessageSquare className="absolute left-3 top-3 text-gray-400 w-5 h-5" />
@@ -702,11 +408,17 @@ function SearchResults() {
                   </div>
                 </div>
 
+                <PrivacyPolicyCheckbox
+                  checked={privacyAccepted}
+                  onChange={setPrivacyAccepted}
+                />
+
                 <button
                   type="submit"
-                  className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors"
+                  disabled={!privacyAccepted}
+                  className="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors disabled:bg-gray-300 disabled:cursor-not-allowed"
                 >
-                  Enviar Mensagem
+                  Solicitar Orçamento
                 </button>
               </form>
             </div>
@@ -755,11 +467,7 @@ function SearchResults() {
                 </div>
               </div> */}
               <button
-                onClick={() => {
-                  setSelectedProfessional(null);
-                  setIsBulkRequest(true);
-                  setShowLGPDTerms(true);
-                }}
+                onClick={() => openQuoteForm(null, true)}
                 className="w-full sm:w-auto flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-xl transition-colors whitespace-nowrap shadow-sm"
               >
                 <Send className="w-5 h-5" />
@@ -850,10 +558,7 @@ function SearchResults() {
 
                     {/* Botão Solicitar Orçamento - Desktop */}
                     <button
-                      onClick={() => {
-                        setShowLGPDTerms(true);
-                        setSelectedProfessional(professional);
-                      }}
+                      onClick={() => openQuoteForm(professional, false)}
                       className={`hidden sm:flex items-center self-start ${
                         professional.isPremium
                           ? "bg-[#FF6B35] hover:bg-[#E55A2B]"
@@ -868,10 +573,7 @@ function SearchResults() {
                 {/* Botão Solicitar Orçamento - Mobile */}
                 <div className="sm:hidden mt-1">
                   <button
-                    onClick={() => {
-                      setShowLGPDTerms(true);
-                      setSelectedProfessional(professional);
-                    }}
+                    onClick={() => openQuoteForm(professional, false)}
                     className={`w-44 ${
                       professional.isPremium
                         ? "bg-[#FF6B35] hover:bg-[#E55A2B]"
@@ -1076,8 +778,7 @@ function SearchResults() {
                   onClick={() => {
                     setModalInfoProfissional(false);
                     setShowExpandedImage(false);
-                    setShowLGPDTerms(true);
-                    setSelectedProfessional(selectedProfessional);
+                    openQuoteForm(selectedProfessional, false);
                   }}
                   className={`${
                     selectedProfessional.telefone &&

--- a/frontend/src/pages/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults.tsx
@@ -22,6 +22,11 @@ import { ProfessionalService } from "../services/ProfessionalService";
 import { useLocation, useNavigate } from "react-router-dom";
 import PrivacyPolicyCheckbox from "../components/PrivacyPolicyCheckbox";
 import {
+  BUDGET_FORM_DRAFT_KEYS,
+  clearBudgetFormDraft,
+  loadBudgetFormDraft,
+} from "../utils/budgetFormDraft";
+import {
   IBudget,
   IProfissional,
 } from "../interfaces";
@@ -42,6 +47,13 @@ interface FormData {
   name: string;
   phone: string;
   message: string;
+}
+
+interface SearchResultsFormDraft {
+  formData: FormData;
+  privacyAccepted: boolean;
+  isBulkRequest: boolean;
+  selectedProfessionalOid: number | null;
 }
 
 // interface SearchResultsProps {
@@ -185,6 +197,42 @@ function SearchResults() {
     fetchData();
   }, []);
 
+  useEffect(() => {
+    if (
+      location.state?.restoreFormDraft !==
+      BUDGET_FORM_DRAFT_KEYS.searchResults
+    ) {
+      return;
+    }
+
+    const draft = loadBudgetFormDraft<SearchResultsFormDraft>(
+      BUDGET_FORM_DRAFT_KEYS.searchResults
+    );
+    if (!draft) return;
+
+    setFormData(draft.formData);
+    setPrivacyAccepted(draft.privacyAccepted);
+    setIsBulkRequest(draft.isBulkRequest);
+    setShowContactForm(true);
+    setShowProfessionalSearch(false);
+
+    if (draft.selectedProfessionalOid && professionals.length > 0) {
+      const professional = professionals.find(
+        (item) => item.oid === draft.selectedProfessionalOid
+      );
+      setSelectedProfessional(professional ?? null);
+    } else {
+      setSelectedProfessional(null);
+    }
+
+    const { restoreFormDraft: _, ...preservedState } =
+      (location.state as Record<string, unknown>) ?? {};
+    navigate(`${location.pathname}${location.search}`, {
+      replace: true,
+      state: preservedState,
+    });
+  }, [location.state?.restoreFormDraft, professionals, location.pathname, location.search, navigate]);
+
   const openQuoteForm = (
     professional: IProfissional | null = null,
     bulk = false
@@ -240,6 +288,7 @@ function SearchResults() {
     const postReturn = await BudgetService.saveBudget(budget);
 
     if (postReturn.status == 200) {
+      clearBudgetFormDraft(BUDGET_FORM_DRAFT_KEYS.searchResults);
       setShowContactForm(false);
       setShowProfessionalSearch(true);
 
@@ -411,6 +460,13 @@ function SearchResults() {
                 <PrivacyPolicyCheckbox
                   checked={privacyAccepted}
                   onChange={setPrivacyAccepted}
+                  formDraftKey={BUDGET_FORM_DRAFT_KEYS.searchResults}
+                  getFormDraft={() => ({
+                    formData,
+                    privacyAccepted,
+                    isBulkRequest,
+                    selectedProfessionalOid: selectedProfessional?.oid ?? null,
+                  })}
                 />
 
                 <button

--- a/frontend/src/services/PageViewService.ts
+++ b/frontend/src/services/PageViewService.ts
@@ -1,0 +1,18 @@
+import Api from "../providers/Api"
+import ApiPublica from "../providers/ApiPublica"
+
+export interface IPageView {
+  id: number
+  path: string
+  count: number
+}
+
+const trackPageView = (path: string) =>
+  ApiPublica.post("/page-view", { path })
+
+const getPageViews = () => Api.get<IPageView[]>("/page-views")
+
+export const PageViewService = {
+  trackPageView,
+  getPageViews,
+}

--- a/frontend/src/utils/budgetFormDraft.ts
+++ b/frontend/src/utils/budgetFormDraft.ts
@@ -1,0 +1,25 @@
+export const BUDGET_FORM_DRAFT_KEYS = {
+  searchResults: "budget-form-search-results",
+  quoteProducts: "budget-form-quote-products",
+} as const
+
+export type BudgetFormDraftKey =
+  (typeof BUDGET_FORM_DRAFT_KEYS)[keyof typeof BUDGET_FORM_DRAFT_KEYS]
+
+export const saveBudgetFormDraft = <T>(key: BudgetFormDraftKey, data: T): void => {
+  sessionStorage.setItem(key, JSON.stringify(data))
+}
+
+export const loadBudgetFormDraft = <T>(key: BudgetFormDraftKey): T | null => {
+  const raw = sessionStorage.getItem(key)
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+export const clearBudgetFormDraft = (key: BudgetFormDraftKey): void => {
+  sessionStorage.removeItem(key)
+}


### PR DESCRIPTION
## Summary

Improves the client budget-request experience and adds page-view analytics for the admin dashboard.

Clients can now submit quotes with fewer fields, accept the privacy policy inline (instead of a separate LGPD modal), and return to a restored draft after reading the privacy policy. Admins can see which routes are most visited, excluding logged-in admin traffic so internal testing does not skew the metrics.

## Problem / motivation

- Budget forms asked for more data than necessary (email, client/city IDs in the form payload), and privacy acceptance lived in a separate LGPD modal — friction that likely reduced quote completions.
- Opening the privacy policy from the form dropped in-progress input, forcing clients to retype everything.
- Product/ops had no visibility into which pages get the most traffic, making it hard to spot bottlenecks or prioritize UX work.

## What changed

### Budget form UX
- Reduced contact/budget forms to **name, phone, and message** on `SearchResults` and `QuoteProducts`.
- Replaced the LGPD modal with an inline `PrivacyPolicyCheckbox` (required acceptance before submit).
- Added `sessionStorage` draft helpers so navigating to `/privacy` and back restores form state (including bulk vs single professional request context).
- Clarified contact form subtitle with professional name/city label (or bulk “send to N professionals”).

### Page-view counting
- New backend `pageview` domain (entity, repository, service, use cases, controllers).
- Public endpoint to increment views; authenticated admin endpoint to list aggregates.
- Frontend `usePageViewTracker` records route changes and **skips** tracking when an admin is logged in.
- New Dashboard section `DashboardPageViews` listing paths sorted by visit count.

## Commits included

- `feat: simplificar formulário de orçamento e política no form`
- `feat: adicionar contador de acessos às páginas`
- `feat: implement budget form draft management and enhance privacy policy navigation`
- `feat: enhance SearchResults component with professional label management and improved contact form subtitle`

## Scope (files)

**Backend (Go):** pageview domain/use cases/repo, public + admin controllers, wiring in `app.go`, AutoMigrate registration.

**Frontend (React):** `PrivacyPolicyCheckbox`, `budgetFormDraft`, `usePageViewTracker`, `PageViewService`, `DashboardPageViews`, updates to `App`, `Dashboard`, `PrivacyPolicy`, `QuoteProducts`, `SearchResults`.

~21 files · +809 / −414

## How to test

### Budget form UX
- [ ] On professional search results, open contact form for one professional — only name, phone, message + privacy checkbox are required
- [ ] Submit without accepting privacy → blocked; accept and submit → success
- [ ] Click “Política de Privacidade” mid-form → values preserved after returning via “Voltar ao formulário”
- [ ] Repeat for bulk “quote all professionals” and for `QuoteProducts` flow
- [ ] Confirm email field is no longer required/shown on these forms

### Page views
- [ ] Browse public routes while logged out → counts increase in Dashboard → “Acessos por Página”
- [ ] Browse the same routes as a logged-in **admin** → counts do **not** increase
- [ ] Empty state shows when no data; list is sorted by highest count first
- [ ] Confirm `GET /page-views` (admin) and public increment endpoint behave as expected after backend restart/migrate

### Edge cases
- [ ] Privacy return with missing/corrupt draft in `sessionStorage` → form opens empty, no crash
- [ ] Soft-fail page-view tracking (API down) → navigation still works (errors swallowed in tracker)

## Technical notes / decisions

- Drafts use **`sessionStorage`** (tab-scoped, cleared when the tab closes) rather than `localStorage`, so incomplete personal data is not persisted across sessions.
- Admin exclusion is based on `localStorage` `profile === "admin"` + presence of `token` — intentional to keep test traffic out of product metrics.
- Page views are path aggregates (path + count), not full analytics (no referrer, device, or session funnel).
- Privacy acceptance moved into the form itself to keep LGPD compliance visible at the point of submission without an extra modal step.

## Risks / follow-ups

- No date filter on this branch; follow-up lives on `HC-001-page-counting-per-date`.
- Removing email from the client form may affect downstream notifications that previously expected email — confirm budget/solicitation flows still work end-to-end.
- Page-view increment is public and fire-and-forget; consider rate limiting later if abuse becomes an issue.

## Checklist

- [x] Conventional commit messages used on the branch
- [x] Types defined for new frontend/backend contracts
- [ ] Manual QA of quote + privacy restore paths
- [ ] Manual QA of page-view increment (anon vs admin)
- [ ] Confirm DB AutoMigrate creates/updates `page_views` (or equivalent) in each environment
- [ ] No leftover debug `console.log` beyond intentional error logging
- [ ] No unrelated junk files in the diff