### PR TITLE
feat(pageview): track daily page views and filter by date range

### DIFF
--- a/backend/app/domain/pageview/entity.go
+++ b/backend/app/domain/pageview/entity.go
@@ -1,9 +1,14 @@
 package pageview
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 type PageView struct {
 	gorm.Model
-	Path  string `gorm:"uniqueIndex;size:255;not null"`
-	Count int64  `gorm:"default:0"`
+	Path     string    `gorm:"uniqueIndex:idx_pageview_path_date;size:255;not null"`
+	ViewDate time.Time `gorm:"uniqueIndex:idx_pageview_path_date;type:date;not null"`
+	Count    int64     `gorm:"default:0"`
 }

--- a/backend/app/usecase/pageview/presenter.go
+++ b/backend/app/usecase/pageview/presenter.go
@@ -5,18 +5,24 @@ import (
 )
 
 type PageViewPresenter struct {
-	ID    uint   `json:"id"`
-	Path  string `json:"path"`
-	Count int64  `json:"count"`
+	ID       uint   `json:"id"`
+	Path     string `json:"path"`
+	ViewDate string `json:"viewDate"`
+	Count    int64  `json:"count"`
 }
 
 func GeneratePageViewPresenter(pageView *pkgpageview.PageView) PageViewPresenter {
 	if pageView == nil {
 		return PageViewPresenter{}
 	}
+	viewDate := ""
+	if !pageView.ViewDate.IsZero() {
+		viewDate = pageView.ViewDate.Format("2006-01-02")
+	}
 	return PageViewPresenter{
-		ID:    pageView.ID,
-		Path:  pageView.Path,
-		Count: pageView.Count,
+		ID:       pageView.ID,
+		Path:     pageView.Path,
+		ViewDate: viewDate,
+		Count:    pageView.Count,
 	}
 }

--- a/backend/infra/database/repositories/pageview/repository-impl.go
+++ b/backend/infra/database/repositories/pageview/repository-impl.go
@@ -2,6 +2,7 @@ package pageview_repository_impl
 
 import (
 	"errors"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -18,13 +19,20 @@ func NewPageViewRepositoryImpl(db *gorm.DB) pkgpageview.PageViewRepository {
 	}
 }
 
+func getTodayDate() time.Time {
+	now := time.Now()
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+}
+
 func (r *repository) Increment(path string) (*pkgpageview.PageView, error) {
+	viewDate := getTodayDate()
 	var pageView pkgpageview.PageView
-	err := r.DB.Where("path = ?", path).First(&pageView).Error
+	err := r.DB.Where("path = ? AND view_date = ?", path, viewDate).First(&pageView).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		pageView = pkgpageview.PageView{
-			Path:  path,
-			Count: 1,
+			Path:     path,
+			ViewDate: viewDate,
+			Count:    1,
 		}
 		if createErr := r.DB.Create(&pageView).Error; createErr != nil {
 			return nil, createErr
@@ -43,7 +51,7 @@ func (r *repository) Increment(path string) (*pkgpageview.PageView, error) {
 
 func (r *repository) FindAll() ([]*pkgpageview.PageView, error) {
 	var pageViews []*pkgpageview.PageView
-	if err := r.DB.Order("count desc").Find(&pageViews).Error; err != nil {
+	if err := r.DB.Order("view_date desc, count desc").Find(&pageViews).Error; err != nil {
 		return nil, err
 	}
 	return pageViews, nil

--- a/frontend/src/pages/DashboardPageViews.tsx
+++ b/frontend/src/pages/DashboardPageViews.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react"
-import { BarChart3 } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { BarChart3, Calendar } from "lucide-react"
 import { IPageView, PageViewService } from "../services/PageViewService"
 
 const formatViewDate = (viewDate: string): string => {
@@ -12,6 +12,8 @@ const formatViewDate = (viewDate: string): string => {
 function DashboardPageViews() {
   const [pageViews, setPageViews] = useState<IPageView[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [dateFrom, setDateFrom] = useState("")
+  const [dateTo, setDateTo] = useState("")
 
   useEffect(() => {
     const fetchPageViews = async () => {
@@ -36,6 +38,22 @@ function DashboardPageViews() {
     fetchPageViews()
   }, [])
 
+  const filteredPageViews = useMemo(() => {
+    return pageViews.filter((pageView) => {
+      if (!pageView.viewDate) return false
+      if (dateFrom && pageView.viewDate < dateFrom) return false
+      if (dateTo && pageView.viewDate > dateTo) return false
+      return true
+    })
+  }, [pageViews, dateFrom, dateTo])
+
+  const hasActiveFilter = dateFrom !== "" || dateTo !== ""
+
+  const handleClearFilter = () => {
+    setDateFrom("")
+    setDateTo("")
+  }
+
   if (isLoading) {
     return <p className="text-gray-600">Carregando acessos...</p>
   }
@@ -57,8 +75,66 @@ function DashboardPageViews() {
         </div>
       </div>
 
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:flex-wrap">
+        <div>
+          <label
+            htmlFor="page-view-date-from"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Data inicial
+          </label>
+          <div className="relative">
+            <Calendar className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <input
+              id="page-view-date-from"
+              type="date"
+              value={dateFrom}
+              onChange={(event) => setDateFrom(event.target.value)}
+              max={dateTo || undefined}
+              className="block w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500"
+              aria-label="Filtrar a partir da data"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label
+            htmlFor="page-view-date-to"
+            className="mb-1 block text-sm font-medium text-gray-700"
+          >
+            Data final
+          </label>
+          <div className="relative">
+            <Calendar className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <input
+              id="page-view-date-to"
+              type="date"
+              value={dateTo}
+              onChange={(event) => setDateTo(event.target.value)}
+              min={dateFrom || undefined}
+              className="block w-full rounded-md border border-gray-300 py-2 pl-9 pr-3 text-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500"
+              aria-label="Filtrar até a data"
+            />
+          </div>
+        </div>
+
+        {hasActiveFilter && (
+          <button
+            type="button"
+            onClick={handleClearFilter}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Limpar filtro
+          </button>
+        )}
+      </div>
+
       {pageViews.length === 0 ? (
         <p className="text-gray-500">Nenhum acesso registrado ainda.</p>
+      ) : filteredPageViews.length === 0 ? (
+        <p className="text-gray-500">
+          Nenhum acesso encontrado para o período selecionado.
+        </p>
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full table-auto text-sm">
@@ -76,7 +152,7 @@ function DashboardPageViews() {
               </tr>
             </thead>
             <tbody>
-              {pageViews.map((pageView) => (
+              {filteredPageViews.map((pageView) => (
                 <tr key={pageView.id} className="border-b border-gray-100">
                   <td className="px-4 py-3 text-gray-700">
                     {formatViewDate(pageView.viewDate)}

--- a/frontend/src/pages/DashboardPageViews.tsx
+++ b/frontend/src/pages/DashboardPageViews.tsx
@@ -2,6 +2,13 @@ import { useEffect, useState } from "react"
 import { BarChart3 } from "lucide-react"
 import { IPageView, PageViewService } from "../services/PageViewService"
 
+const formatViewDate = (viewDate: string): string => {
+  if (!viewDate) return "-"
+  const [year, month, day] = viewDate.split("-")
+  if (!year || !month || !day) return viewDate
+  return `${day}/${month}/${year}`
+}
+
 function DashboardPageViews() {
   const [pageViews, setPageViews] = useState<IPageView[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -11,7 +18,12 @@ function DashboardPageViews() {
       try {
         const response = await PageViewService.getPageViews()
         if (response.status === 200) {
-          const sorted = [...response.data].sort((a, b) => b.count - a.count)
+          const sorted = [...response.data].sort((a, b) => {
+            if (a.viewDate !== b.viewDate) {
+              return b.viewDate.localeCompare(a.viewDate)
+            }
+            return b.count - a.count
+          })
           setPageViews(sorted)
         }
       } catch (error) {
@@ -39,8 +51,8 @@ function DashboardPageViews() {
             Acessos por Página
           </h3>
           <p className="text-sm text-gray-600">
-            Páginas com mais visitas podem indicar gargalos ou oportunidades.
-            Acessos de admin logado não são contabilizados.
+            Contagem diária por rota. Acessos de admin logado não são
+            contabilizados.
           </p>
         </div>
       </div>
@@ -53,6 +65,9 @@ function DashboardPageViews() {
             <thead className="bg-gray-50">
               <tr className="border-b border-gray-200">
                 <th className="px-4 py-3 text-left font-medium text-gray-500">
+                  Data
+                </th>
+                <th className="px-4 py-3 text-left font-medium text-gray-500">
                   Página
                 </th>
                 <th className="px-4 py-3 text-right font-medium text-gray-500">
@@ -63,6 +78,9 @@ function DashboardPageViews() {
             <tbody>
               {pageViews.map((pageView) => (
                 <tr key={pageView.id} className="border-b border-gray-100">
+                  <td className="px-4 py-3 text-gray-700">
+                    {formatViewDate(pageView.viewDate)}
+                  </td>
                   <td className="px-4 py-3 text-gray-900 font-mono">
                     {pageView.path}
                   </td>

--- a/frontend/src/services/PageViewService.ts
+++ b/frontend/src/services/PageViewService.ts
@@ -4,6 +4,7 @@ import ApiPublica from "../providers/ApiPublica"
 export interface IPageView {
   id: number
   path: string
+  viewDate: string
   count: number
 }
 


### PR DESCRIPTION
## Summary

Evolves page-view analytics from lifetime totals per route into **daily counts**, and adds date-range filtering on the admin dashboard so the team can inspect traffic for a specific period.

Builds on the page-view feature merged in #29 (`HC-001-improve-form-ux-and-page-counting`).

## Problem / motivation

- Lifetime aggregates (`path` → single `count`) made it impossible to answer “how many visits did `/search` get last week?” or compare days.
- Without a date dimension, spikes and regressions were flattened into one number, reducing the value of the dashboard for spotting bottlenecks or campaign impact.
- Admins needed a simple way to narrow the table to a period without exporting raw data.

## What changed

### Backend — daily page views
- Added `ViewDate` (`date`) to the `PageView` entity.
- Replaced unique index on `path` alone with composite unique index `idx_pageview_path_date` on `(path, view_date)`.
- `Increment` now upserts against **path + today’s date** (server local day boundary).
- `FindAll` orders by `view_date desc, count desc`.
- Presenter exposes `viewDate` as `YYYY-MM-DD`.

### Frontend — dashboard UX
- `IPageView` includes `viewDate`.
- Dashboard table shows a **Data** column (formatted `dd/mm/yyyy`).
- Rows sorted by date (newest first), then by count.
- Date range filters: **Data inicial** / **Data final**, with `min`/`max` constraints between them.
- **Limpar filtro** clears the range; empty filtered result shows a period-specific empty state.

## Commits included

- `feat: enhance page view tracking with date and update dashboard display`
- `feat: add date filtering to DashboardPageViews component`

## Scope (files)

| Layer | Files |
|-------|--------|
| Domain | `backend/app/domain/pageview/entity.go` |
| Use case | `backend/app/usecase/pageview/presenter.go` |
| Repository | `backend/infra/database/repositories/pageview/repository-impl.go` |
| UI | `frontend/src/pages/DashboardPageViews.tsx` |
| Client API type | `frontend/src/services/PageViewService.ts` |

5 files · +133 / −19

## How to test

### Daily counting
- [ ] Restart backend so AutoMigrate applies the new `view_date` column / index
- [ ] As a logged-out (or non-admin) user, visit a public route twice on the same day → one row for that path+today with `count = 2`
- [ ] Confirm a second day (or change system date in a controlled test env) creates a **new** row for the same path
- [ ] Logged-in **admin** visits still do **not** increment counts

### Dashboard filtering
- [ ] Open Dashboard → “Acessos por Página” → see Date / Page / Count columns
- [ ] Set only **Data inicial** → rows before that date disappear
- [ ] Set only **Data final** → rows after that date disappear
- [ ] Set both → only rows inside the inclusive range remain
- [ ] **Limpar filtro** restores the full list
- [ ] Filter with no matching rows → “Nenhum acesso encontrado para o período selecionado.”
- [ ] No data at all → “Nenhum acesso registrado ainda.”

### Edge cases
- [ ] `Data inicial` after `Data final` prevented by input `min`/`max`
- [ ] Records with empty/zero `viewDate` are excluded from the filtered list (defensive)

## Technical notes / decisions

- **Grain changed from “per path forever” to “per path per calendar day.”** This is intentional so historical days remain queryable; totals across days are the sum of daily rows.
- Date “today” is computed on the **server** (`time.Now()` truncated to local midnight). Deploy timezone matters for day boundaries — document/ops should know which TZ the API host uses.
- Dashboard filtering is **client-side** over the full `GET /page-views` payload (simple, no API contract change for filters). Fine for current volume; if the table grows large, move range filters to query params on the backend.
- API response shape gains `viewDate` (non-breaking for consumers that ignore unknown fields; required for this UI).

## Risks / follow-ups

- **Schema migration risk:** old unique index was on `path` only. Existing rows have no `view_date`. Confirm AutoMigrate (or a manual migration) handles backfill / index rebuild safely in each environment before deploy; otherwise increment/create may fail or duplicate unexpectedly.
- No server-side date filter yet — all history is fetched every dashboard load.
- No cross-day aggregation UI (e.g. “total for path in range”); reviewers/users must sum mentally or export later if needed.
- Related prior work: page-view foundation from PR #29.

## Checklist

- [x] Conventional commits on the branch
- [x] Frontend types updated for `viewDate`
- [ ] AutoMigrate / DB change verified on a DB that already has lifetime page-view rows
- [ ] Manual QA of increment (same day vs new day)
- [ ] Manual QA of date filters + clear
- [ ] Confirmed admin traffic still excluded
- [ ] No unrelated junk files in the diff